### PR TITLE
Remove duplicate dev/production domain determining

### DIFF
--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -39,7 +39,6 @@ class Menu_Structure {
 
 	private function addHomeMenu() {
 
-		$base = apply_filters( 'yoast:domain', 'https://yoast.com/' );
 		$mainMenuItem = new Main_Menu_Item(
 			$this->yoastComBaseUrl,
 			array(

--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -310,38 +310,6 @@ class Menu_Structure {
 		$this->mainMenuItems[] = $mainMenuItem;
 	}
 
-	private function getYoastComBaseUrl() {
-		if ( $this->development ) {
-			return 'http://yoast.dev/';
-		}
-
-		return 'https://yoast.com/';
-	}
-
-	private function getMyYoastBaseUrl() {
-		if ( $this->development ) {
-			return 'http://my.yoast.dev/';
-		}
-
-		return 'https://my.yoast.com/';
-	}
-
-	private function getAcademyBaseUrl() {
-		if ( $this->development ) {
-			return 'http://yoast.academy.dev/';
-		}
-
-		return 'https://yoast.academy/';
-	}
-
-	private function getKBBaseUrl() {
-		if ( $this->development ) {
-			return 'http://kb.yoast.dev/';
-		}
-
-		return 'https://kb.yoast.com/';
-	}
-
 	/**
 	 * Gets all menuItems.
 	 *

--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -12,18 +12,17 @@ class Menu_Structure {
 	const FAQ_TYPE = 'faq';
 
 	private $mainMenuItems;
+
 	private $yoastComBaseUrl;
 	private $myYoastBaseUrl;
-	private $development = false;
+	private $academyBaseUrl;
+	private $kbBaseUrl;
 
 	public function __construct() {
-		if ( defined( 'YOAST_ENVIRONMENT' ) && YOAST_ENVIRONMENT === 'development' ) {
-			$this->development = true;
-		}
-		$this->yoastComBaseUrl = $this->getYoastComBaseUrl();
-		$this->myYoastBaseUrl  = $this->getmyYoastBaseUrl();
-		$this->academyBaseUrl  = $this->getAcademyBaseUrl();
-		$this->kbBaseUrl       = $this->getKBBaseUrl();
+		$this->yoastComBaseUrl = apply_filters( 'yoast:domain', 'https://yoast.com/' );
+		$this->myYoastBaseUrl  = apply_filters( 'yoast:domain', 'https://my.yoast.com/' );
+		$this->academyBaseUrl  = apply_filters( 'yoast:domain', 'https://yoast.academy/' );
+		$this->kbBaseUrl       = apply_filters( 'yoast:domain', 'https://kb.yoast.com/' );
 
 		$this->createMenuItems();
 	}
@@ -40,6 +39,7 @@ class Menu_Structure {
 
 	private function addHomeMenu() {
 
+		$base = apply_filters( 'yoast:domain', 'https://yoast.com/' );
 		$mainMenuItem = new Main_Menu_Item(
 			$this->yoastComBaseUrl,
 			array(


### PR DESCRIPTION
Centralize domain and URL control to the use of a filter, applied in the theme.
If the filter is not implemented it will fallback to the production URLs.