### PR TITLE
Add keyword research

### DIFF
--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -347,16 +347,6 @@ class Menu_Structure {
 
 		$mainMenuItem->addChild(
 			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/seo-copywriting-training/',
-				array(
-					'label' => 'SEO copywriting',
-					'type'  => self::COURSES_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
 				$this->yoastComBaseUrl . 'academy/course/basic-seo-training/',
 				array(
 					'label' => 'Basic SEO',
@@ -370,6 +360,26 @@ class Menu_Structure {
 				$this->yoastComBaseUrl . 'academy/course/yoast-seo-wordpress-training/',
 				array(
 					'label' => 'Yoast SEO for WordPress',
+					'type'  => self::COURSES_TYPE,
+				)
+			)
+		);
+
+		$mainMenuItem->addChild(
+			new Menu_Item(
+				$this->yoastComBaseUrl . 'academy/course/seo-copywriting-training/',
+				array(
+					'label' => 'SEO copywriting',
+					'type'  => self::COURSES_TYPE,
+				)
+			)
+		);
+
+		$mainMenuItem->addChild(
+			new Menu_Item(
+				$this->yoastComBaseUrl . 'academy/course/keyword-research-training/',
+				array(
+					'label' => 'Keyword research',
 					'type'  => self::COURSES_TYPE,
 				)
 			)

--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -357,9 +357,9 @@ class Menu_Structure {
 
 		$mainMenuItem->addChild(
 			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/yoast-seo-wordpress-training/',
+				$this->yoastComBaseUrl . 'academy/course/seo-copywriting-training/',
 				array(
-					'label' => 'Yoast SEO for WordPress',
+					'label' => 'SEO copywriting',
 					'type'  => self::COURSES_TYPE,
 				)
 			)
@@ -367,9 +367,9 @@ class Menu_Structure {
 
 		$mainMenuItem->addChild(
 			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/seo-copywriting-training/',
+				$this->yoastComBaseUrl . 'academy/course/yoast-seo-wordpress-training/',
 				array(
-					'label' => 'SEO copywriting',
+					'label' => 'Yoast SEO for WP',
 					'type'  => self::COURSES_TYPE,
 				)
 			)


### PR DESCRIPTION
Re-organize the courses in the menu

<img width="811" alt="online_seo_training__follow_an_online_course_at_yoast" src="https://cloud.githubusercontent.com/assets/2005352/19265603/0812a61c-8fa6-11e6-8fd0-a39b10552728.png">

Instead of:

<img width="704" alt="keyword_research_training_ _yoast" src="https://cloud.githubusercontent.com/assets/2005352/19265622/1f489b16-8fa6-11e6-8530-fc46d1ba40f4.png">

Thus making it a more natural order.
Starting off with "Basic" SEO, needed by everybody, followed by Yoast SEO and finished off with specific SEO topics for everybody.

Fixes https://github.com/Yoast/yoast.com/issues/606