### PR TITLE
remove hire us from menu

### DIFF
--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -18,7 +18,6 @@ class Menu_Structure {
 	const PLUGINS_TYPE = 'plugins';
 	const COURSES_TYPE = 'courses';
 	const EBOOKS_TYPE = 'ebooks';
-	const HIRE_US_TYPE = 'hire-us';
 	const FAQ_TYPE = 'faq';
 
 	private $menuItems;
@@ -88,7 +87,6 @@ class Menu_Structure {
 		$this->addPluginsMenu();
 		$this->addCoursesMenu();
 		$this->addEBooksMenu();
-		$this->addHireUsMenu();
 		$this->addFAQMenu();
 	}
 
@@ -471,54 +469,6 @@ class Menu_Structure {
 				)
 			)
 		);
-
-		$this->menuItems[] = $mainMenuItem;
-	}
-
-	/**
-	 * Create the Hire Us menu
-	 */
-	private function addHireUsMenu() {
-
-		$mainMenuItem = new Main_Menu_Item(
-			$this->yoastComBaseUrl . 'hire-us/',
-			array(
-				'label'    => 'Hire us',
-				'type'     => self::HIRE_US_TYPE,
-				'activeOn' => array( $this->yoastComBaseUrl => array( 'post' ) ),
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'hire-us/yoast-seo-care/',
-				array(
-					'label' => 'Yoast SEO Care',
-					'type'  => self::HIRE_US_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'hire-us/yoast-seo-configuration/',
-				array(
-					'label' => 'Yoast SEO configuration',
-					'type'  => self::HIRE_US_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'hire-us/seo-consultancy/',
-				array(
-					'label' => 'Yoast consultancy',
-					'type'  => self::HIRE_US_TYPE,
-				)
-			)
-		);
-
 
 		$this->menuItems[] = $mainMenuItem;
 	}


### PR DESCRIPTION
Removed all code involving the menu item "hire-us".

Goes along with: https://github.com/Yoast/Yoast-theme-public/pull/158

**How to test:**
Apply both branches. This is key!

**Issues with testing:**
First, I have applied it directly to master and the changes were successful. After resetting the changes and making a branch together with @terw-dan, we can no longer test it.