### PR TITLE
Stories/update menu

### DIFF
--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -86,7 +86,6 @@ class Menu_Structure {
 		$this->addSEOBlogMenu();
 		$this->addPluginsMenu();
 		$this->addCoursesMenu();
-		$this->addEBooksMenu();
 		$this->addFAQMenu();
 	}
 
@@ -134,15 +133,15 @@ class Menu_Structure {
 			)
 		);
 
-        $mainMenuItem->addChild(
-            new Menu_Item(
-                $this->yoastComBaseUrl . 'conference/',
-                array(
-                    'label' => 'YoastCon',
-                    'type'  => self::HOME_TYPE,
-                )
-            )
-        );
+		$mainMenuItem->addChild(
+			new Menu_Item(
+				$this->yoastComBaseUrl . 'conference/',
+				array(
+					'label' => 'YoastCon',
+					'type'  => self::HOME_TYPE,
+				)
+			)
+		);
 
 		$mainMenuItem->addChild(
 			new Menu_Item(

--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -327,7 +327,7 @@ class Menu_Structure {
 				'type'     => self::COURSES_TYPE,
 				'activeOn' => array(
 					$this->academyBaseUrl  => array(),
-					$this->yoastComBaseUrl => array( 'yoast_courses' ),
+					$this->yoastComBaseUrl => array( 'yoast_courses' , 'yoast_ebooks'),
 				),
 			)
 		);

--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -366,63 +366,6 @@ class Menu_Structure {
 	}
 
 	/**
-	 * Create the E-Books menu
-	 */
-	private function addEBooksMenu() {
-
-		$mainMenuItem = new Main_Menu_Item(
-			$this->yoastComBaseUrl . 'ebooks/',
-			array(
-				'label'    => 'eBooks',
-				'type'     => self::EBOOKS_TYPE,
-				'activeOn' => array( $this->yoastComBaseUrl => array( 'yoast_ebooks' ) ),
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'ebooks/seo-for-wordpress/',
-				array(
-					'label' => 'SEO for WordPress',
-					'type'  => self::EBOOKS_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'ebooks/shop-seo/',
-				array(
-					'label' => 'Shop SEO',
-					'type'  => self::EBOOKS_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'ebooks/content-seo-2/',
-				array(
-					'label' => 'Content SEO',
-					'type'  => self::EBOOKS_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'ebooks/ux-conversion-seo/',
-				array(
-					'label' => 'UX & Conversion',
-					'type'  => self::EBOOKS_TYPE,
-				)
-			)
-		);
-
-		$this->menuItems[] = $mainMenuItem;
-	}
-
-	/**
 	 * Create the FAQ menu
 	 */
 	private function addFAQMenu() {

--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -277,7 +277,7 @@ class Menu_Structure {
 		$mainMenuItem = new Main_Menu_Item(
 			$this->yoastComBaseUrl . 'wordpress/plugins/',
 			array(
-				'label'    => 'Plugins',
+				'label'    => 'WordPress plugins',
 				'type'     => self::PLUGINS_TYPE,
 				'activeOn' => array( $this->yoastComBaseUrl => array( 'yoast_plugins', 'yoast_dev_article' ) ),
 			)
@@ -313,16 +313,6 @@ class Menu_Structure {
 			)
 		);
 
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->myYoastBaseUrl . 'account/',
-				array(
-					'label' => 'Licenses',
-					'type'  => self::PLUGINS_TYPE,
-				)
-			)
-		);
-
 		$this->menuItems[] = $mainMenuItem;
 	}
 
@@ -334,7 +324,7 @@ class Menu_Structure {
 		$mainMenuItem = new Main_Menu_Item(
 			$this->yoastComBaseUrl . 'academy/courses/',
 			array(
-				'label'    => 'Courses',
+				'label'    => 'SEO Courses',
 				'type'     => self::COURSES_TYPE,
 				'activeOn' => array(
 					$this->academyBaseUrl  => array(),
@@ -345,69 +335,29 @@ class Menu_Structure {
 
 		$mainMenuItem->addChild(
 			new Menu_Item(
+				$this->yoastComBaseUrl . 'academy/courses/',
+				array(
+					'label' => 'Courses',
+					'type'  => self::COURSES_TYPE,
+				)
+			)
+		);
+
+		$mainMenuItem->addChild(
+			new Menu_Item(
+				$this->yoastComBaseUrl . 'ebooks/',
+				array(
+					'label'    => 'eBooks',
+					'type'     => self::COURSES_TYPE,
+				)
+			)
+		);
+
+		$mainMenuItem->addChild(
+			new Menu_Item(
 				$this->academyBaseUrl . 'my-courses/',
 				array(
 					'label' => 'My Academy',
-					'type'  => self::COURSES_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/basic-seo-training/',
-				array(
-					'label' => 'Basic SEO',
-					'type'  => self::COURSES_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/seo-copywriting-training/',
-				array(
-					'label' => 'SEO copywriting',
-					'type'  => self::COURSES_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/technical-seo-1-training/',
-				array(
-					'label' => 'Technical SEO',
-					'type'  => self::COURSES_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/yoast-seo-wordpress-training/',
-				array(
-					'label' => 'Yoast SEO for WP',
-					'type'  => self::COURSES_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/course/structured-data-training',
-				array(
-					'label' => 'Structured data',
-					'type'  => self::COURSES_TYPE,
-				)
-			)
-		);
-
-		$mainMenuItem->addChild(
-			new Menu_Item(
-				$this->yoastComBaseUrl . 'academy/courses/',
-				array(
-					'label' => 'More courses »',
 					'type'  => self::COURSES_TYPE,
 				)
 			)


### PR DESCRIPTION
fixes https://github.com/Yoast/yoast.com/issues/1294

**How to test:**
- Removed ebooks from main menu
- Added ebooks to courses tab
- Removed all courses and replaced this with a single "courses".
- Switch positions of the submenu items of Courses (should be Courses, eBooks, My Academy)
- Renamed main-menu "Courses" tot "SEO Courses"