### PR TITLE
change "drupal module" to "other platforms" and change the url

### DIFF
--- a/php/class-menu-structure.php
+++ b/php/class-menu-structure.php
@@ -304,9 +304,9 @@ class Menu_Structure {
 
 		$mainMenuItem->addChild(
 			new Menu_Item(
-				$this->yoastComBaseUrl . 'software/yoast-seo-for-drupal-module/',
+				$this->yoastComBaseUrl . 'yoast-seo-platforms/',
 				array(
-					'label' => 'Drupal module',
+					'label' => 'Other platforms',
 					'type'  => self::PLUGINS_TYPE,
 				)
 			)


### PR DESCRIPTION
fixes https://github.com/Yoast/yoast.com/issues/1501

**how to test**

- checkout the branch
- See if the menu-item "Drupal module" changed to "Other platforms"
- Check if the link goes to https://yoast.com/yoast-seo-platforms/